### PR TITLE
Fix CoreCLR Version & add nuget sources

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -61,7 +61,13 @@ Task("Restore-NuGet-Packages")
   var settings = new DotNetCoreRestoreSettings
   {
     Verbose = false,
-    Verbosity = DotNetCoreRestoreVerbosity.Warning
+    Verbosity = DotNetCoreRestoreVerbosity.Warning,
+    Sources = new [] {
+        "https://www.myget.org/F/xunit/api/v3/index.json",
+        "https://dotnet.myget.org/F/dotnet-core/api/v3/index.json",
+        "https://dotnet.myget.org/F/cli-deps/api/v3/index.json",
+        "https://api.nuget.org/v3/index.json",
+    }
   };
 
   DotNetCoreRestore("./src", settings);

--- a/build.ps1
+++ b/build.ps1
@@ -31,13 +31,13 @@ Function Install-Dotnet()
     # Download the dotnet CLI install script
     if (!(Test-Path .\dotnet\install.ps1))
     {
-      Write-Output "Downloading latest version of Dotnet CLI..."
-      Invoke-WebRequest "https://raw.githubusercontent.com/dotnet/cli/rel/1.0.0/scripts/obtain/dotnet-install.ps1" -OutFile ".\.dotnet\dotnet-install.ps1"
+      Write-Output "Downloading version 1.0.0-preview2 of Dotnet CLI installer..."
+      Invoke-WebRequest "https://raw.githubusercontent.com/dotnet/cli/rel/1.0.0-preview2/scripts/obtain/dotnet-install.ps1" -OutFile ".\.dotnet\dotnet-install.ps1"
     }
 
     # Run the dotnet CLI install
-    Write-Output "Installing Dotnet CLI..."
-    & .\.dotnet\dotnet-install.ps1
+    Write-Output "Installing Dotnet CLI version 1.0.0-preview1-002702..."
+    & .\.dotnet\dotnet-install.ps1 -Channel beta -Version 1.0.0-preview1-002702
 
     # Add the dotnet folder path to the process. This gets skipped
     # by Install-DotNetCli if it's already installed.
@@ -65,7 +65,7 @@ $PSScriptRoot = split-path -parent $MyInvocation.MyCommand.Definition;
 $Script = Join-Path $PSScriptRoot "build.cake"
 $ToolPath = Join-Path $PSScriptRoot "tools"
 $NuGetPath = Join-Path $ToolPath "nuget/NuGet.exe"
-$CakeVersion = "0.12.0"
+$CakeVersion = "0.13.0"
 $CakePath = Join-Path $ToolPath "Cake.$CakeVersion/Cake.exe"
 
 # Install Dotnet CLI.


### PR DESCRIPTION
* Nancy currently compiles with Preview 1 but not Preview 2, so fixes version.
* Updated Cake to latest version
* dotnet cli doesn't support encrypted sources, specifying sources works around breaking if people have private feeds locally